### PR TITLE
Fix several profile bugs and add tests

### DIFF
--- a/automation/BrowserManager.py
+++ b/automation/BrowserManager.py
@@ -130,7 +130,7 @@ class Browser:
                 status_strings = ['Profile Created','Profile Tar','Display','Launch Attempted', 'Browser Launched', 'Browser Ready']
                 for string in status_strings:
                     error_string += " | %s: %s " % (string, launch_status.get(string, False))
-                self.logger.error("BROWSER %i: Spawn unsuccessful %s" % error_string)
+                self.logger.error("BROWSER %i: Spawn unsuccessful %s" % (self.crawl_id, error_string))
                 self.kill_browser_manager()
                 if self.current_profile_path is not None:
                     shutil.rmtree(self.current_profile_path, ignore_errors=True)
@@ -206,12 +206,13 @@ class Browser:
             else:
                 self.command_thread.join(60)
             self.logger.debug("BROWSER %i: %f seconds to join command thread" % (self.crawl_id, time.time() - start_time))
-        
+
         # Kill BrowserManager process and children
         self.logger.debug("BROWSER %i: Killing browser manager..." % self.crawl_id)
         self.kill_browser_manager()
 
         # Archive browser profile (if requested)
+        self.logger.debug("BROWSER %i: during_init=%s | profile_archive_dir=%s" % (self.crawl_id, str(during_init), self.browser_params['profile_archive_dir']))
         if not during_init and self.browser_params['profile_archive_dir'] is not None:
             self.logger.debug("BROWSER %i: Archiving browser profile directory to %s" % (self.crawl_id, self.browser_params['profile_archive_dir']))
             profile_commands.dump_profile(self.current_profile_path,

--- a/automation/BrowserManager.py
+++ b/automation/BrowserManager.py
@@ -4,14 +4,20 @@ from Commands import profile_commands
 from Proxy import deploy_mitm_proxy
 from SocketInterface import clientsocket
 from MPLogger import loggingclient
+from Errors import ProfileLoadError
 
 from multiprocessing import Process, Queue
 from Queue import Empty as EmptyQueue
+from tblib import pickling_support
+pickling_support.install()
+from six import reraise
 import tempfile
 import logging
+import cPickle
 import shutil
 import signal
 import time
+import sys
 import os
 
 class Browser:
@@ -85,6 +91,15 @@ class Browser:
         unsuccessful_spawns = 0
         retry = False
         success = False
+
+        def check_queue(launch_status):
+            result = self.status_queue.get(True, spawn_timeout)
+            if result[0] == 'STATUS':
+                launch_status[result[1]] = True
+                return result[2]
+            elif result[0] == 'CRITICAL':
+                reraise(*cPickle.loads(result[1]))
+
         while not success and unsuccessful_spawns < 4:
             self.logger.debug("BROWSER %i: Spawn attempt %i " % (self.crawl_id, unsuccessful_spawns))
             # Resets the command/status queues
@@ -97,27 +112,25 @@ class Browser:
             self.browser_manager.start()
 
             # Read success status of browser manager
-            prof_done = prof_tar_done = disp_done = browser_done = ready_done = launch_attempted = False
+            launch_status = dict()
             try:
-                self.current_profile_path = self.status_queue.get(True, spawn_timeout)
-                prof_done = True
-                useless = self.status_queue.get(True, spawn_timeout)
-                prof_tar_done = True
-                (self.display_pid, self.display_port) = self.status_queue.get(True, spawn_timeout)
-                disp_done = True
-                useless = self.status_queue.get(True, spawn_timeout)
-                launch_attempted = True
-                (self.browser_pid, self.browser_settings) = self.status_queue.get(True, spawn_timeout)
-                browser_done = True
-                if self.status_queue.get(True, spawn_timeout) != 'READY':
+                self.current_profile_path = check_queue(launch_status) # selenium profile created
+                check_queue(launch_status) # profile tar loaded (if necessary)
+                (self.display_pid, self.display_port) = check_queue(launch_status) # Display launched
+                check_queue(launch_status) # browser launch attempted
+                (self.browser_pid, self.browser_settings) = check_queue(launch_status) # Browser launched
+                if check_queue(launch_status) != 'READY':
                     self.logger.error("BROWSER %i: Mismatch of status queue return values, trying again..." % self.crawl_id)
                     unsuccessful_spawns += 1
                     continue
                 success = True
             except EmptyQueue:
                 unsuccessful_spawns += 1
-                self.logger.error("BROWSER %i: Spawn unsuccessful | Profile Created: %s | Profile Tar: %s | Display: %s | Launch attempted: %s | Browser: %s" %
-                        (self.crawl_id, str(prof_done), str(prof_tar_done), str(disp_done), str(launch_attempted), str(browser_done)))
+                error_string = ''
+                status_strings = ['Profile Created','Profile Tar','Display','Launch Attempted', 'Browser Launched', 'Browser Ready']
+                for string in status_strings:
+                    error_string += " | %s: %s " % (string, launch_status.get(string, False))
+                self.logger.error("BROWSER %i: Spawn unsuccessful %s" % error_string)
                 self.kill_browser_manager()
                 if self.current_profile_path is not None:
                     shutil.rmtree(self.current_profile_path, ignore_errors=True)
@@ -182,7 +195,7 @@ class Browser:
                 self.logger.debug("BROWSER %i: Browser process does not exist" % self.crawl_id)
                 pass
 
-    def shutdown_browser(self):
+    def shutdown_browser(self, during_init):
         """ Runs the closing tasks for this Browser/BrowserManager """
         # Join command thread
         if self.command_thread is not None:
@@ -199,7 +212,7 @@ class Browser:
         self.kill_browser_manager()
 
         # Archive browser profile (if requested)
-        if self.browser_params['profile_archive_dir'] is not None:
+        if not during_init and self.browser_params['profile_archive_dir'] is not None:
             self.logger.debug("BROWSER %i: Archiving browser profile directory to %s" % (self.crawl_id, self.browser_params['profile_archive_dir']))
             profile_commands.dump_profile(self.current_profile_path,
                                           self.manager_params,
@@ -222,50 +235,50 @@ def BrowserManager(command_queue, status_queue, browser_params, manager_params, 
     and interface with Selenium. Command execution status is sent back
     to the TaskManager.
     """
-    logger = loggingclient(*manager_params['logger_address'])
-    
-    # Start the proxy
-    proxy_site_queue = None  # used to pass the current site down to the proxy
-    if browser_params['proxy']:
-        (local_port, proxy_site_queue) = deploy_mitm_proxy.init_proxy(browser_params,
-                                                                      manager_params)
-        browser_params['proxy'] = local_port
+    try:
+        logger = loggingclient(*manager_params['logger_address'])
+        
+        # Start the proxy
+        proxy_site_queue = None  # used to pass the current site down to the proxy
+        if browser_params['proxy']:
+            (local_port, proxy_site_queue) = deploy_mitm_proxy.init_proxy(browser_params,
+                                                                          manager_params)
+            browser_params['proxy'] = local_port
 
-    # Start the virtualdisplay (if necessary), webdriver, and browser
-    (driver, prof_folder, browser_settings) = deploy_browser.deploy_browser(status_queue, browser_params, manager_params, crash_recovery)
+        # Start the virtualdisplay (if necessary), webdriver, and browser
+        (driver, prof_folder, browser_settings) = deploy_browser.deploy_browser(status_queue, browser_params, manager_params, crash_recovery)
 
-    # Read the extension port -- if extension is enabled
-    # TODO: This needs to be cleaner
-    if browser_params['browser'] == 'firefox' and browser_params['extension']['enabled']:
-        logger.debug("BROWSER %i: Looking for extension port information in %s" % (browser_params['crawl_id'], prof_folder))
-        while not os.path.isfile(prof_folder + 'extension_port.txt'):
-            time.sleep(0.1)
-        time.sleep(0.5)
-        with open(prof_folder + 'extension_port.txt', 'r') as f:
-            port = f.read().strip()
-        extension_socket = clientsocket()
-        extension_socket.connect('127.0.0.1',int(port))
-    else:
-        extension_socket = None
+        # Read the extension port -- if extension is enabled
+        # TODO: This needs to be cleaner
+        if browser_params['browser'] == 'firefox' and browser_params['extension']['enabled']:
+            logger.debug("BROWSER %i: Looking for extension port information in %s" % (browser_params['crawl_id'], prof_folder))
+            while not os.path.isfile(prof_folder + 'extension_port.txt'):
+                time.sleep(0.1)
+            time.sleep(0.5)
+            with open(prof_folder + 'extension_port.txt', 'r') as f:
+                port = f.read().strip()
+            extension_socket = clientsocket()
+            extension_socket.connect('127.0.0.1',int(port))
+        else:
+            extension_socket = None
 
-    # passes the profile folder, WebDriver pid and display pid back to the TaskManager
-    # now, the TaskManager knows that the browser is successfully set up
-    status_queue.put('READY')
-    browser_params['profile_path'] = prof_folder
+        # passes the profile folder, WebDriver pid and display pid back to the TaskManager
+        # now, the TaskManager knows that the browser is successfully set up
+        status_queue.put(('STATUS','Browser Ready','READY'))
+        browser_params['profile_path'] = prof_folder
 
-    # starts accepting arguments until told to die
-    while True:
-        # no command for now -> sleep to avoid pegging CPU on blocking get
-        if command_queue.empty():
-            time.sleep(0.001)
-            continue
+        # starts accepting arguments until told to die
+        while True:
+            # no command for now -> sleep to avoid pegging CPU on blocking get
+            if command_queue.empty():
+                time.sleep(0.001)
+                continue
 
-        # reads in the command tuple of form (command, arg0, arg1, arg2, ..., argN) where N is variable
-        command = command_queue.get()
-        logger.info("BROWSER %i: EXECUTING COMMAND: %s" % (browser_params['crawl_id'], str(command)))
-        # attempts to perform an action and return an OK signal
-        # if command fails for whatever reason, tell the TaskMaster to kill and restart its worker processes
-        try:
+            # reads in the command tuple of form (command, arg0, arg1, arg2, ..., argN) where N is variable
+            command = command_queue.get()
+            logger.info("BROWSER %i: EXECUTING COMMAND: %s" % (browser_params['crawl_id'], str(command)))
+            # attempts to perform an action and return an OK signal
+            # if command fails for whatever reason, tell the TaskMaster to kill and restart its worker processes
             command_executor.execute_command(command,
                                              driver,
                                              proxy_site_queue,
@@ -274,7 +287,12 @@ def BrowserManager(command_queue, status_queue, browser_params, manager_params, 
                                              manager_params,
                                              extension_socket)
             status_queue.put("OK")
-        except Exception as e:
-            logger.info("BROWSER %i: Crash in driver, restarting browser manager \n %s \n %s" % (browser_params['crawl_id'], str(type(e)), str(e)))
-            status_queue.put("FAILED")
-            break
+    except ProfileLoadError:
+        logger.info("BROWSER %i: ProfileLoadError thrown, informing parent and raising" % browser_params['crawl_id'])
+        err_info = sys.exc_info()
+        status_queue.put(('CRITICAL',cPickle.dumps(err_info)))
+        return
+    except Exception as e:
+        logger.info("BROWSER %i: Crash in driver, restarting browser manager \n %s \n %s" % (browser_params['crawl_id'], str(type(e)), str(e)))
+        status_queue.put("FAILED")
+        return

--- a/automation/Commands/profile_commands.py
+++ b/automation/Commands/profile_commands.py
@@ -4,6 +4,7 @@ import shutil
 import sys
 import os
 
+from ..Errors import ProfileLoadError
 from ..MPLogger import loggingclient
 from utils.firefox_profile import sleep_until_sqlite_checkpoint
 from utils.file_utils import rmsubtree
@@ -162,10 +163,10 @@ def load_profile(browser_profile_folder, manager_params, browser_params, tar_loc
     unzips it to <browser_profile_folder>. This will load whatever profile
     is in the folder, either full_profile.tar.gz or profile.tar.gz
     """
-    # Connect to logger
-    logger = loggingclient(*manager_params['logger_address'])
-    
     try:
+        # Connect to logger
+        logger = loggingclient(*manager_params['logger_address'])
+        
         # ensures that folder paths end with slashes
         browser_profile_folder = browser_profile_folder if browser_profile_folder.endswith("/") \
             else browser_profile_folder + "/"
@@ -195,9 +196,8 @@ def load_profile(browser_profile_folder, manager_params, browser_params, tar_loc
 
         # load the browser settings
         browser_settings = load_browser_settings(tar_location)
-
     except Exception as ex:
-        logger.error("BROWSER %i: Error: %s while attempting to load profile" % (browser_params['crawl_id'],str(ex)))
-        browser_settings = None
+        logger.critical("BROWSER %i: Error: %s while attempting to load profile" % (browser_params['crawl_id'],str(ex)))
+        raise ProfileLoadError('Profile Load not successful')
 
     return browser_settings

--- a/automation/DeployBrowsers/deploy_firefox.py
+++ b/automation/DeployBrowsers/deploy_firefox.py
@@ -23,7 +23,7 @@ def deploy_firefox(status_queue, browser_params, manager_params, crash_recovery)
     display_port = None
     fp = webdriver.FirefoxProfile()
     browser_profile_path = fp.path + '/'
-    status_queue.put(browser_profile_path)
+    status_queue.put(('STATUS','Profile Created',browser_profile_path))
 
     # Enable logging
     #LOGGER.setLevel(logging.WARNING)
@@ -39,7 +39,7 @@ def deploy_firefox(status_queue, browser_params, manager_params, crash_recovery)
         logger.debug("BROWSER %i: Loading recovered browser profile from: %s" % (browser_params['crawl_id'], browser_params['profile_tar']))
         profile_settings = load_profile(browser_profile_path, manager_params, browser_params,
                                         browser_params['profile_tar'])
-    status_queue.put('profile_success')
+    status_queue.put(('STATUS','Profile Tar',None))
     
     if browser_params['random_attributes'] and profile_settings is None:
         logger.debug("BROWSER %i: Loading random attributes for browser" % browser_params['crawl_id'])
@@ -74,7 +74,7 @@ def deploy_firefox(status_queue, browser_params, manager_params, crash_recovery)
         display.start()
         display_pid = display.pid
         display_port = display.cmd_param[5][1:]
-    status_queue.put((display_pid, display_port))
+    status_queue.put(('STATUS','Display',(display_pid, display_port)))
 
     if browser_params['debugging']:
         firebug_loc = os.path.join(root_dir, 'firefox_extensions/firebug-1.11.0.xpi')
@@ -126,11 +126,11 @@ def deploy_firefox(status_queue, browser_params, manager_params, crash_recovery)
     configure_firefox.optimize_prefs(fp)
 
     # Launch the webdriver
-    status_queue.put("LAUNCHING BROWSER")
+    status_queue.put(('STATUS','Launch Attempted',None))
     #fb = FirefoxBinary(root_dir  + "/../../firefox/firefox", log_file=open(root_dir + '/../../firefox_logging','w'))
     fb = FirefoxBinary(root_dir  + "/../../firefox/firefox")
     driver = webdriver.Firefox(firefox_profile=fp, firefox_binary=fb)
-    status_queue.put((int(driver.binary.process.pid), profile_settings))
+    status_queue.put(('STATUS','Browser Launched',(int(driver.binary.process.pid), profile_settings)))
 
     # set window size
     driver.set_window_size(*profile_settings['screen_res'])

--- a/automation/Errors.py
+++ b/automation/Errors.py
@@ -6,3 +6,9 @@ class CommandExecutionError(Exception):
         self.message = message
         self.command = command
         super(CommandExecutionError, self).__init__(message, command, *args)
+
+class ProfileLoadError(Exception):
+    """ Raise for errors related to executing commands """
+    def __init__(self, message, *args):
+        self.message = message
+        super(ProfileLoadError, self).__init__(message, *args)

--- a/automation/TaskManager.py
+++ b/automation/TaskManager.py
@@ -56,9 +56,11 @@ class TaskManager:
     """
 
     def __init__(self, manager_params, browser_params, process_watchdog=False, task_description=None):
+
         # Make paths absolute in manager_params
-        manager_params['data_directory'] = os.path.expanduser(manager_params['data_directory'])
-        manager_params['log_directory'] = os.path.expanduser(manager_params['log_directory'])
+        for path in ['data_directory','log_directory','profile_archive_dir']:
+            if manager_params[path] is not None:
+                manager_params[path] = os.path.expanduser(manager_params[path])
         manager_params['database_name'] = os.path.join(manager_params['data_directory'],manager_params['database_name'])
         manager_params['log_file'] = os.path.join(manager_params['log_directory'],manager_params['log_file'])
         self.manager_params = manager_params

--- a/automation/TaskManager.py
+++ b/automation/TaskManager.py
@@ -2,13 +2,15 @@ from BrowserManager import Browser
 from DataAggregator import DataAggregator, LevelDBAggregator
 from SocketInterface import clientsocket
 from PostProcessing import post_processing
-from Errors import CommandExecutionError
+from Errors import CommandExecutionError, ProfileLoadError
 import MPLogger
 
 from multiprocessing import Process, Queue
 from Queue import Empty as EmptyQueue
 from sqlite3 import OperationalError
+from six import reraise
 import threading
+import cPickle
 import copy
 import os
 import sqlite3
@@ -61,11 +63,20 @@ class TaskManager:
         manager_params['log_file'] = os.path.join(manager_params['log_directory'],manager_params['log_file'])
         self.manager_params = manager_params
         
+        # check size of parameter dictionary
+        self.num_browsers = manager_params['num_browsers']
+        if len(browser_params) != self.num_browsers:
+            raise Exception("Number of <browser_params> dicts is not the same as manager_params['num_browsers']")
+        
         # Flow control
         self.closing = False
         self.failure_flag = False
         self.threadlock = threading.Lock()
         self.failurecount = 0
+        if manager_params['failure_limit'] is not None:
+            self.failure_limit = manager_params['failure_limit']
+        else:
+            self.failure_limit = self.num_browsers * 2 + 10
         
         self.desc = task_description
         self.process_watchdog = process_watchdog
@@ -78,11 +89,6 @@ class TaskManager:
         with open(os.path.join(os.path.dirname(__file__), 'schema.sql'), 'r') as f:
             self.db.executescript(f.read())
         
-        # check size of parameter dictionary
-        self.num_browsers = manager_params['num_browsers']
-        if len(browser_params) != self.num_browsers:
-            raise Exception("Number of <browser_params> dicts is not the same as manager_params['num_browsers']")
-
         # sets up logging server + connect a client
         self.logging_status_queue = None
         self.loggingserver = self._launch_loggingserver()
@@ -150,7 +156,12 @@ class TaskManager:
     def _launch_browsers(self):
         """ launch each browser manager process / browser """
         for browser in self.browsers:
-            success = browser.launch_browser_manager()
+            try:
+                success = browser.launch_browser_manager()
+            except:
+                self._cleanup_before_fail(during_init=True)
+                raise
+                
             if not success:
                 self.logger.critical("Browser spawn failure during TaskManager initialization, exiting...")
                 self.close(post_process=False)
@@ -258,16 +269,17 @@ class TaskManager:
         self.logging_status_queue.put("DIE")
         self.loggingserver.join(300)
 
-    def _shutdown_manager(self, failure=False):
+    def _shutdown_manager(self, failure=False, during_init=False):
         """
         Wait for current commands to finish, close all child processes and
         threads
         <failure> flag to indicate manager failure (True) or end of crawl (False)
+        <during_init> flag to indicator if this shutdown is occuring during the TaskManager initialization
         """
         self.closing = True
         
         for browser in self.browsers:
-            browser.shutdown_browser()
+            browser.shutdown_browser(during_init)
             if failure:
                 self.sock.send(("UPDATE crawl SET finished = -1 WHERE crawl_id = ?",
                                 (browser.crawl_id,)))
@@ -280,13 +292,14 @@ class TaskManager:
         self._kill_aggregators()
         self._kill_loggingserver()
 
-    def _gracefully_fail(self, msg, command):
+    def _cleanup_before_fail(self, during_init=False):
         """
-        Execute shutdown commands before throwing error
-        <msg>: an Exception will be raised with this message
+        Execute shutdown commands before throwing an exception
+        This should keep us from having a bunch of hanging processes
+        and incomplete data.
+        <during_init> flag to indicator if this shutdown is occuring during the TaskManager initialization
         """
-        self._shutdown_manager(failure=True)
-        raise CommandExecutionError(msg, command)
+        self._shutdown_manager(failure=True, during_init=during_init)
 
     # CRAWLER COMMAND CODE
 
@@ -356,7 +369,8 @@ class TaskManager:
             return
         if self.failure_flag:
             self.logger.debug("TaskManager failure threshold exceeded, raising CommandExecutionError")
-            self._gracefully_fail("TaskManager failure threshold exceeded", command)
+            self._cleanup_before_fail()
+            raise CommandExecutionError("TaskManager failure threshold exceeded", command)
 
         # Start command execution thread
         args = (browser, command, reset, condition)
@@ -384,6 +398,12 @@ class TaskManager:
         # received reply from BrowserManager, either success signal or failure notice
         try:
             status = browser.status_queue.get(True, browser.current_timeout)
+            if type(status) == tuple and status[0] == 'CRITICAL':
+                self.logger.info("BROWSER %i: Received an exception while executing command: %s" % (browser.crawl_id, command[0]))
+                command_succeeded = 0
+                self.failure_flag = True
+                self._cleanup_before_fail()
+                reraise(*cPickle.loads(status[1]))
             if status == "OK":
                 command_succeeded = 1
             else:
@@ -403,7 +423,7 @@ class TaskManager:
         if command_succeeded != 1:
             with self.threadlock:
                 self.failurecount += 1
-            if self.failurecount > self.num_browsers * 2 + 10:
+            if self.failurecount > self.failure_limit:
                 self.logger.critical("BROWSER %i: Command execution failure pushes failure count above the allowable limit. Setting failure_flag." % browser.crawl_id)
                 self.failure_flag = True
                 return

--- a/automation/TaskManager.py
+++ b/automation/TaskManager.py
@@ -58,7 +58,7 @@ class TaskManager:
     def __init__(self, manager_params, browser_params, process_watchdog=False, task_description=None):
 
         # Make paths absolute in manager_params
-        for path in ['data_directory','log_directory','profile_archive_dir']:
+        for path in ['data_directory','log_directory']:
             if manager_params[path] is not None:
                 manager_params[path] = os.path.expanduser(manager_params[path])
         manager_params['database_name'] = os.path.join(manager_params['data_directory'],manager_params['database_name'])

--- a/automation/TaskManager.py
+++ b/automation/TaskManager.py
@@ -266,20 +266,8 @@ class TaskManager:
         """
         self.closing = True
         
-        for i in range(len(self.browsers)):
-            browser = self.browsers[i]
-            if browser.command_thread is not None:
-                self.logger.debug("BROWSER %i: Joining command thread" % browser.crawl_id)
-                start_time = time.time()
-                if browser.current_timeout is not None:
-                    browser.command_thread.join(browser.current_timeout + 10)
-                else:
-                    browser.command_thread.join(60)
-                self.logger.debug("BROWSER %i: %f seconds to join command thread" % (browser.crawl_id, time.time() - start_time))
-            self.logger.debug("BROWSER %i: Killing browser manager..." % browser.crawl_id)
-            browser.kill_browser_manager()
-            if browser.current_profile_path is not None:
-                shutil.rmtree(browser.current_profile_path, ignore_errors = True)
+        for browser in self.browsers:
+            browser.shutdown_browser()
             if failure:
                 self.sock.send(("UPDATE crawl SET finished = -1 WHERE crawl_id = ?",
                                 (browser.crawl_id,)))

--- a/automation/default_browser_params.json
+++ b/automation/default_browser_params.json
@@ -13,6 +13,7 @@
     "disable_flash": true,
     "debugging": false,
     "profile_tar": null,
+    "profile_archive_dir": null,
     "headless": false,
     "browser": "firefox",
     

--- a/automation/default_manager_params.json
+++ b/automation/default_manager_params.json
@@ -2,5 +2,6 @@
     "data_directory": "~/openwpm/",
     "log_directory": "~/openwpm/",
     "database_name": "crawl-data.sqlite",
-    "log_file": "openwpm.log"
+    "log_file": "openwpm.log",
+    "failure_limit": null
 }

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ sudo apt-get update
 sudo apt-get install firefox htop git python-dev python-pip libxml2-dev libxslt-dev libffi-dev libssl-dev build-essential xvfb libboost-python-dev libleveldb1 libleveldb-dev libjpeg-dev
 
 sudo pip install -U setuptools
-sudo pip install -U pyvirtualdisplay beautifulsoup4 netlib pyasn1 PyOPenSSL python-dateutil tld pyamf psutil mitmproxy pyhash plyvel
+sudo pip install -U pyvirtualdisplay beautifulsoup4 netlib pyasn1 PyOPenSSL python-dateutil tld pyamf psutil mitmproxy pyhash plyvel tblib
 
 # Install specific version of Firefox and selenium
 # known to work well together.

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ sudo -H python get-pip.py
 rm get-pip.py
 
 sudo -H pip install -U setuptools
-sudo -H pip install -U pyvirtualdisplay beautifulsoup4 pyasn1 PyOPenSSL python-dateutil tld pyamf psutil pyhash plyvel
+sudo -H pip install -U pyvirtualdisplay beautifulsoup4 pyasn1 PyOPenSSL python-dateutil tld pyamf psutil pyhash plyvel tblib
 
 # Install specific mitmproxy version since we rely on some internal structure of 
 # netlib and mitmproxy. New releases tend to break things and should be tested

--- a/install.sh
+++ b/install.sh
@@ -31,9 +31,9 @@ sudo -H pip install -U pyvirtualdisplay beautifulsoup4 pyasn1 PyOPenSSL python-d
 sudo -H  pip install mitmproxy==0.13
 
 # Install specific version of selenium known to work well with the Firefox install below
-sudo -H pip install selenium==2.47.1
+sudo -H pip install selenium==2.48.0
 
 # Install specific version of Firefox known to work well with the selenium version above
-wget https://ftp.mozilla.org/pub/mozilla.org/firefox/releases/39.0.3/linux-x86_64/en-US/firefox-39.0.3.tar.bz2
+wget https://ftp.mozilla.org/pub/firefox/releases/41.0.2/linux-x86_64/en-US/firefox-41.0.2.tar.bz2 
 tar jxf firefox*.tar.bz2 -C ./
 rm firefox*.tar.bz2

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,13 @@
 sudo apt-get update
 
-sudo apt-get install firefox htop git python-dev python-pip libxml2-dev libxslt-dev libffi-dev libssl-dev build-essential xvfb libboost-python-dev libleveldb1 libleveldb-dev libjpeg-dev
+sudo apt-get install firefox htop git python-dev libxml2-dev libxslt-dev libffi-dev libssl-dev build-essential xvfb libboost-python-dev libleveldb1 libleveldb-dev libjpeg-dev
 
-sudo pip install -U setuptools
-sudo pip install -U pyvirtualdisplay beautifulsoup4 netlib pyasn1 PyOPenSSL python-dateutil tld pyamf psutil mitmproxy pyhash plyvel tblib
+wget https://bootstrap.pypa.io/get-pip.py
+sudo -H python get-pip.py
+rm get-pip.py
+
+sudo -H pip install -U setuptools
+sudo -H pip install -U pyvirtualdisplay beautifulsoup4 netlib pyasn1 PyOPenSSL python-dateutil tld pyamf psutil mitmproxy pyhash plyvel tblib
 
 # Install specific version of Firefox and selenium
 # known to work well together.

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,10 @@ rm get-pip.py
 sudo -H pip install -U setuptools
 sudo -H pip install -U pyvirtualdisplay beautifulsoup4 netlib pyasn1 PyOPenSSL python-dateutil tld pyamf psutil mitmproxy pyhash plyvel tblib
 
+# Install specific mitmproxy version since we rely on some internal structure of 
+# netlib and mitmproxy. New releases tend to break things and should be tested
+sudo pip install mitmproxy==0.13
+
 # Install specific version of Firefox and selenium
 # known to work well together.
 sudo pip install selenium==2.47.1

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -1,0 +1,42 @@
+import pytest
+import os
+
+from ..automation import TaskManager
+from ..automation.Errors import CommandExecutionError, ProfileLoadError
+
+class TestProfile():
+    NUM_BROWSERS = 1
+
+    def get_config(self, data_dir):
+        manager_params, browser_params = TaskManager.load_default_params(self.NUM_BROWSERS)
+        manager_params['data_directory'] = data_dir
+        manager_params['log_directory'] = data_dir
+        browser_params[0]['profile_archive_dir'] = os.path.join(data_dir,'browser_profile')
+        browser_params[0]['headless'] = True
+        return manager_params, browser_params
+
+    def test_saving(self, tmpdir):
+        manager_params, browser_params = self.get_config(str(tmpdir))
+        manager = TaskManager.TaskManager(manager_params, browser_params)
+        manager.get('http://example.com')
+        manager.close(post_process=False)
+        assert os.path.isfile(os.path.join(browser_params[0]['profile_archive_dir'],'profile.tar.gz'))
+    
+    def test_crash(self, tmpdir):
+        manager_params, browser_params = self.get_config(str(tmpdir))
+        manager_params['failure_limit'] = 0
+        manager = TaskManager.TaskManager(manager_params, browser_params)
+        with pytest.raises(CommandExecutionError):
+            manager.get('http://example.com') # So we have a profile
+            manager.get('example.com') # Selenium requires scheme prefix
+            manager.get('example.com') # Requires two commands to shut down
+
+    def test_profile_error(self, tmpdir):
+        manager_params, browser_params = self.get_config(str(tmpdir))
+        browser_params[0]['profile_tar'] = '/tmp/NOTREAL'
+        with pytest.raises(ProfileLoadError):
+            manager = TaskManager.TaskManager(manager_params, browser_params)
+
+    #TODO Check for Flash
+    #TODO Check contents of profile (tests should fail anyway if profile doesn't contain everything)
+    #TODO Check contents of profile databases

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -21,7 +21,7 @@ class TestProfile():
         manager.get('http://example.com')
         manager.close(post_process=False)
         assert os.path.isfile(os.path.join(browser_params[0]['profile_archive_dir'],'profile.tar.gz'))
-    
+
     def test_crash(self, tmpdir):
         manager_params, browser_params = self.get_config(str(tmpdir))
         manager_params['failure_limit'] = 0
@@ -30,6 +30,20 @@ class TestProfile():
             manager.get('http://example.com') # So we have a profile
             manager.get('example.com') # Selenium requires scheme prefix
             manager.get('example.com') # Requires two commands to shut down
+
+    def test_crash_profile(self, tmpdir):
+        manager_params, browser_params = self.get_config(str(tmpdir))
+        manager_params['failure_limit'] = 2
+        manager = TaskManager.TaskManager(manager_params, browser_params)
+        try:
+            manager.get('http://example.com') # So we have a profile
+            manager.get('example.com') # Selenium requires scheme prefix
+            manager.get('example.com') # Selenium requires scheme prefix
+            manager.get('example.com') # Selenium requires scheme prefix
+            manager.get('example.com') # Requires two commands to shut down
+        except CommandExecutionError:
+            pass
+        assert os.path.isfile(os.path.join(browser_params[0]['profile_archive_dir'],'profile.tar.gz'))
 
     def test_profile_error(self, tmpdir):
         manager_params, browser_params = self.get_config(str(tmpdir))

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -1,8 +1,51 @@
+from publicsuffix import PublicSuffixList, fetch
+from urlparse import urlparse
+import sqlite3
+import tarfile
+import codecs
 import pytest
 import os
 
 from ..automation import TaskManager
 from ..automation.Errors import CommandExecutionError, ProfileLoadError
+
+PSL_CACHE_LOC = '/tmp/public_suffix_list.dat'
+TEST_SITES = [
+    'http://google.com',
+    'http://facebook.com',
+    'http://youtube.com',
+    'http://yahoo.com',
+    'http://baidu.com',
+    'http://wikipedia.org',
+    'http://qq.com',
+    'http://linkedin.com',
+    'http://taobao.com',
+    'http://twitter.com',
+    'http://live.com',
+    'http://amazon.com',
+    'http://sina.com.cn',
+    'http://google.co.in',
+    'http://hao123.com',
+    'http://blogspot.com',
+    'http://weibo.com',
+    'http://wordpress.com',
+    'http://yandex.ru',
+    'http://yahoo.co.jp'
+]
+
+def get_psl():
+    """
+    Grabs an updated public suffix list.
+    """
+    if not os.path.isfile(PSL_CACHE_LOC):
+        print "%s does not exist, downloading a copy." % PSL_CACHE_LOC
+        psl_file = fetch()
+        with codecs.open(PSL_CACHE_LOC, 'w', encoding='utf8') as f:
+            f.write(psl_file.read())
+    psl_cache = codecs.open(PSL_CACHE_LOC, encoding='utf8')
+    return PublicSuffixList(psl_cache)
+
+psl = get_psl()
 
 class TestProfile():
     NUM_BROWSERS = 1
@@ -51,6 +94,74 @@ class TestProfile():
         with pytest.raises(ProfileLoadError):
             manager = TaskManager.TaskManager(manager_params, browser_params)
 
+    def test_browser_profile_coverage(self, tmpdir):
+        # Run the test crawl
+        data_dir = os.path.join(str(tmpdir),'data_dir')
+        manager_params, browser_params = self.get_config(data_dir)
+        manager = TaskManager.TaskManager(manager_params, browser_params)
+        for site in TEST_SITES:
+            manager.get(site)
+        fp = manager.browsers[0].current_profile_path
+        ff_db_tar = os.path.join(browser_params[0]['profile_archive_dir'],'profile.tar.gz')
+        manager.close(post_process=False)
+        
+        # Extract crawl profile
+        with tarfile.open(ff_db_tar) as tar:
+            tar.extractall(browser_params[0]['profile_archive_dir'])
+        
+        # Output databases
+        ff_db = os.path.join(browser_params[0]['profile_archive_dir'],'places.sqlite')
+        crawl_db = os.path.join(manager_params['data_directory'], manager_params['database_name'])
+        
+        # Grab urls from crawl database
+        crawl_con = sqlite3.connect(crawl_db)
+        ccur = crawl_con.cursor()
+
+        req_ps = set()
+        ccur.execute("SELECT url FROM http_requests")
+        for url, in ccur.fetchall():
+            req_ps.add(psl.get_public_suffix(urlparse(url).hostname))
+
+        hist_ps = set()
+        successes = dict()
+        ccur.execute("SELECT arguments, bool_success FROM CrawlHistory WHERE command='GET'")
+        for url, success in ccur.fetchall():
+            ps = psl.get_public_suffix(urlparse(url).hostname)
+            hist_ps.add(ps)
+            successes[ps] = success
+
+        # Grab urls from Firefox database
+        profile_con = sqlite3.connect(ff_db)
+        pcur = profile_con.cursor()
+        profile_ps = set()
+        pcur.execute("SELECT url FROM moz_places")
+        for host, in pcur.fetchall():
+            try:
+                profile_ps.add(psl.get_public_suffix(urlparse(host).hostname))
+            except AttributeError:
+                pass
+        profile_con.close()
+
+        # We expect urls to be in the Firefox profile if:
+        # 1. We've made requests to it
+        # 2. The url is a top_url we entered into the address bar
+        # 3. The url successfully loaded (see: Issue #40)
+        # 4. The site does not respond to the initial request with a 204 (won't show in FF DB)
+        missing_urls = req_ps.intersection(hist_ps).difference(profile_ps)
+        unexpected_missing_urls = set()
+        for url in missing_urls:
+            if successes[url] == 0 or successes[url] == -1:
+                continue
+            ccur.execute("SELECT COUNT(*) FROM http_responses WHERE top_url = ?",('http://'+url,))
+            if ccur.fetchone()[0] > 1:
+                continue
+            ccur.execute("SELECT response_status FROM http_responses WHERE top_url = ?",('http://'+url,))
+            if ccur.fetchone()[0] == 204:
+                continue
+            unexpected_missing_url.add(url)
+
+        crawl_con.close()
+        assert len(unexpected_missing_urls) == 0
+
     #TODO Check for Flash
     #TODO Check contents of profile (tests should fail anyway if profile doesn't contain everything)
-    #TODO Check contents of profile databases


### PR DESCRIPTION
These changes should make profile handling more intuitive and stable under various crawl conditions. Profile errors are now treated as critical and will stop crawls (to avoid a crawl continuing after a profile fails to load correctly). Profiles should remain persistent through crashes, and profiles should always be written on shut down (through the new `profile_archive_dir` option).

Follow up bugfixes to come in #40.