### PR TITLE
Run continuous integration tests using Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: required
+language: python
+os: linux
+dist: trusty
+git:
+  depth: 3
+before_install:
+  - "export DISPLAY=:99.0"
+  - "npm install -g jpm"
+install:
+  - echo "y" | ./install.sh
+  - pip install -r requirements.txt
+before_script:
+  - cd test
+script:
+  - py.test -s -v

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-OpenWPM
+OpenWPM[![Build Status](https://travis-ci.org/citp/OpenWPM.svg)](https://travis-ci.org/citp/OpenWPM)
 =======
 
 OpenWPM is a web privacy measurement framework which makes it easy to collect

--- a/automation/DataAggregator/LevelDBAggregator.py
+++ b/automation/DataAggregator/LevelDBAggregator.py
@@ -1,7 +1,7 @@
 from ..SocketInterface import serversocket
 from ..MPLogger import loggingclient
 import plyvel
-import pyhash
+import mmh3
 import zlib
 import time
 import os
@@ -75,7 +75,7 @@ def process_script(script, batch, db, counter, logger):
     adds a script to the batch
     """
     # Hash script for deduplication on disk
-    hasher = pyhash.murmur3_x64_128()
+    hasher = mmh3.hash128
     script_hash = str(hasher(script) >> 64)
 
     if db.get(script_hash) is not None:

--- a/automation/Proxy/mitm_commands.py
+++ b/automation/Proxy/mitm_commands.py
@@ -3,7 +3,7 @@
 
 from urlparse import urlparse
 import datetime
-import pyhash
+import mmh3
 import json
 import zlib
 import os
@@ -110,7 +110,7 @@ def save_javascript_content(ldb_socket, logger, browser_params, msg):
     ldb_socket.send(script)
 
     # Hash script for deduplication on disk
-    hasher = pyhash.murmur3_x64_128()
+    hasher = mmh3.hash128
     script_hash = str(hasher(script) >> 64)
 
     return script_hash

--- a/automation/platform_utils.py
+++ b/automation/platform_utils.py
@@ -13,7 +13,7 @@ import os
 
 def get_version():
     """Return OpenWPM version tag/current commit and Firefox version """
-    openwpm = subprocess.check_output(["git","describe","--tags"]).strip()
+    openwpm = subprocess.check_output(["git","describe","--always"]).strip()
 
     ff_ini = os.path.join(os.path.dirname(__file__), '../firefox-bin/application.ini')
     with open(ff_ini, 'r') as f:

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -ev
+
 echo "Would you like to install Adobe Flash Player? (Only required for crawls with Flash) [y,N]"
 read -s -n 1 response
 if [[ $response = "" ]] || [ $response == 'n' ] || [ $response == 'N' ]; then
@@ -14,24 +17,19 @@ fi
 
 sudo apt-get update
 
-sudo apt-get install firefox htop git python-dev libxml2-dev libxslt-dev libffi-dev libssl-dev build-essential xvfb libboost-python-dev libleveldb1 libleveldb-dev libjpeg-dev
+sudo apt-get install -y firefox htop git python-dev libxml2-dev libxslt-dev libffi-dev libssl-dev build-essential xvfb libboost-python-dev libleveldb1 libleveldb-dev libjpeg-dev
 if [ "$flash" = true ]; then
-    sudo apt-get install adobe-flashplugin
+    sudo apt-get install -y adobe-flashplugin
 fi
 
-wget https://bootstrap.pypa.io/get-pip.py
-sudo -H python get-pip.py
-rm get-pip.py
-
-sudo -H pip install -U setuptools
-sudo -H pip install -U pyvirtualdisplay beautifulsoup4 pyasn1 PyOPenSSL python-dateutil tld pyamf psutil pyhash plyvel tblib tabulate pytest publicsuffix
-
-# Install specific mitmproxy version since we rely on some internal structure of
-# netlib and mitmproxy. New releases tend to break things and should be tested
-sudo -H  pip install mitmproxy==0.13
-
-# Install specific version of selenium known to work well with the Firefox install below
-sudo -H pip install selenium==2.53.0
+# Check if we're running on continuous integration
+# Python requirements are already installed by .travis.yml on Travis
+if [ "$TRAVIS" != "true" ]; then
+	wget https://bootstrap.pypa.io/get-pip.py
+	sudo -H python get-pip.py
+	rm get-pip.py
+	sudo pip install -r requirements.txt
+fi
 
 # Install specific version of Firefox known to work well with the selenium version above
 wget https://ftp.mozilla.org/pub/firefox/releases/45.0.1/linux-x86_64/en-US/firefox-45.0.1.tar.bz2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,20 @@
+setuptools
+pyvirtualdisplay
+beautifulsoup4
+pyasn1
+PyOPenSSL
+python-dateutil
+tld
+pyamf
+psutil
+plyvel
+tblib
+tabulate
+pytest
+publicsuffix
+# Install specific mitmproxy version since we rely on some internal structure of
+# netlib and mitmproxy. New releases tend to break things and should be tested
+mitmproxy==0.13
+# Install specific version of selenium known to work well with the Firefox install we use
+selenium==2.53.0
+mmh3

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -15,7 +15,7 @@ class TestDependencies(OpenWPMTest):
         # use  requirements.txt to test the dependencies
         py_pkgs = ["setuptools", "pyvirtualdisplay", "beautifulsoup4",
                    "pyasn1", "pyOpenSSL", "python-dateutil", "tld", "pyamf",
-                   "psutil", "pyhash", "plyvel", "tblib", "tabulate",
+                   "psutil", "mmh3", "plyvel", "tblib", "tabulate",
                    "pytest", "publicsuffix"]
 
         for pkg in py_pkgs:


### PR DESCRIPTION
This PR adds .travis.yml file to run continuous integration tests on Travis.

Install pytest for Travis tests.

Move python dependencies to requirements.txt to make it compatible with Travis.

Use mmh3 instead of pyhash.
pyhash cannot be installed on Travis due to an outdated check for
libboost_python.so. mmh3 has the same functionality and it's better
maintained.