### PR TITLE
Wait for homepage to load after back before looking up links

### DIFF
--- a/automation/Commands/browser_commands.py
+++ b/automation/Commands/browser_commands.py
@@ -170,6 +170,7 @@ def browse_website(url, num_links, sleep, visit_id, webdriver, proxy_queue,
             if browser_params['bot_mitigation']:
                 bot_mitigation(webdriver)
             webdriver.back()
+            wait_until_loaded(webdriver, 300)
         except Exception, e:
             pass
 


### PR DESCRIPTION
Without this, it's possible that the homepage isn't given enough time to load and no links are found.