### PR TITLE
Remove webdriver HTML attribute from documentElement and navigator

### DIFF
--- a/automation/Extension/firefox/data/content.js
+++ b/automation/Extension/firefox/data/content.js
@@ -343,6 +343,13 @@ function getPageScript() {
       };
     }
 
+    function removeWebdriverAttributes(){
+      if ("webdriver" in navigator){
+        delete window.navigator["webdriver"];
+      }
+      document.documentElement.removeAttribute("webdriver");
+    }
+
     // Log properties of prototypes and objects
     function logProperty(object, objectName, property, logSettings) {
       var propDesc = Object.getPropertyDescriptor(object, property);
@@ -388,6 +395,9 @@ function getPageScript() {
      * Start Instrumentation
      */
     // TODO: user should be able to choose what to instrument
+
+    // Remove "webdriver" attributes from the DOM (Issue #91)
+    removeWebdriverAttributes();
 
     // Access to navigator properties
     var navigatorProperties = [ "appCodeName", "appName", "appVersion", "buildID", "cookieEnabled", "doNotTrack", "geolocation", "language", "languages", "onLine", "oscpu", "platform", "product", "productSub", "userAgent", "vendorSub", "vendor" ];


### PR DESCRIPTION
Fixes #91.

The fix assumes that OpenWPM's `content.js` runs _after_  Selenium code linked below.

- https://github.com/SeleniumHQ/selenium/blob/b82512999938d41f6765ce8017284dcabe437d4c/javascript/firefox-driver/extension/content/server.js#L49
- https://github.com/SeleniumHQ/selenium/blob/b82512999938d41f6765ce8017284dcabe437d4c/javascript/firefox-driver/extension/content/dommessenger.js#L98

Manually tested on https://output.jsbin.com/webawamabu.

The console logs should read:
```
- Successfully started all instrumentation
- navigator.webdriver:  undefined
- webdriver in navigator:  false
- documentElement attribute webdriver:  null

```