### PR TITLE
Fix test page URL and asserts in the HTTP stacktrace test.

### DIFF
--- a/test/expected.py
+++ b/test/expected.py
@@ -155,8 +155,8 @@ http_cached_responses = {
 }
 
 # HTTP request call stack instrumentation
-# Expected stack frames from http_stack_trace.html page
-HTTP_STACKTRACE_TEST_URL = BASE_TEST_URL + "/http_stack_trace.html"
+# Expected stack frames
+HTTP_STACKTRACE_TEST_URL = BASE_TEST_URL + "/http_stacktrace.html"
 stack_trace_inject_image =\
     "inject_image@" + HTTP_STACKTRACE_TEST_URL + ":18:7;null\n"\
     "inject_all@" + HTTP_STACKTRACE_TEST_URL + ":22:7;null\n"\
@@ -165,29 +165,30 @@ stack_trace_inject_image =\
 RAWGIT_HTTP_STACKTRACE_TEST_URL = "https://rawgit.com/gunesacar/b927d3fe69f3e7bf456da5192f74beea/raw/8d3e490b5988c633101ec45ef1443e61b1fd495e/inject_pixel.js"  # noqa
 stack_trace_inject_pixel =\
     "inject_pixel@" + RAWGIT_HTTP_STACKTRACE_TEST_URL + ":4:3;null\n"\
-    "null@" + RAWGIT_HTTP_STACKTRACE_TEST_URL + ":6:1;null\n"
+    "null@" + RAWGIT_HTTP_STACKTRACE_TEST_URL + ":6:1;null"
 
 stack_trace_inject_js =\
     "inject_js@" + HTTP_STACKTRACE_TEST_URL + ":13:7;null\n"\
     "inject_all@" + HTTP_STACKTRACE_TEST_URL + ":21:7;null\n"\
     "onload@" + HTTP_STACKTRACE_TEST_URL + ":1:1;null"
 
+http_stacktraces = set((stack_trace_inject_image, stack_trace_inject_pixel, stack_trace_inject_js))
 # parsed HTTP call stack dict
 call_stack_inject_image =\
     [{"func_name": "inject_image",
-     "filename": BASE_TEST_URL + "/http_stack_trace.html",
+     "filename": HTTP_STACKTRACE_TEST_URL,
      "line_no": "18",
      "col_no": "7",
      "async_cause": "null"
      },
     {"func_name": "inject_all",
-     "filename": BASE_TEST_URL + "/http_stack_trace.html",
+     "filename": HTTP_STACKTRACE_TEST_URL,
      "line_no": "22",
      "col_no": "7",
      "async_cause": "null"
      },
     {"func_name": "onload",
-     "filename": BASE_TEST_URL + "/http_stack_trace.html",
+     "filename": HTTP_STACKTRACE_TEST_URL,
      "line_no": "1",
      "col_no": "1",
      "async_cause": "null"

--- a/test/test_pages/http_stacktrace.html
+++ b/test/test_pages/http_stacktrace.html
@@ -6,7 +6,7 @@
 	// inject a script using appendChild
 	// the script will load a pixel
     function inject_js() {
-  	  var js=window.document.createElement("script");
+      var js=window.document.createElement("script");
       js.setAttribute("async","true");
       js.type="text/javascript"
       js.src="https://rawgit.com/gunesacar/b927d3fe69f3e7bf456da5192f74beea/raw/8d3e490b5988c633101ec45ef1443e61b1fd495e/inject_pixel.js";


### PR DESCRIPTION
The test_http_instrumentation.py test was passing without even running the asserts due to a typo on the URL.
DRY in the expected.py.
Fix tab-space mix up in the test page.