### PR TITLE
Make visit_id = -1 when visit_id would otherwise be null

### DIFF
--- a/automation/Extension/firefox/lib/loggingdb.js
+++ b/automation/Extension/firefox/lib/loggingdb.js
@@ -196,11 +196,14 @@ exports.createInsert = function(table, update) {
         visitID = listeningSocket.queue.shift();
         exports.logDebug("Visit Id: " + visitID);
     }
+
+    update["visit_id"] = visitID;
+    
     if (!visitID && !debugging) {
         exports.logCritical('Extension-' + crawlID + ' : visitID is null while attempting to insert ' +
                     JSON.stringify(update));
+        update["visit_id"] = -1;
     }
-    update["visit_id"] = visitID;
 
     var statement = "INSERT INTO " + table + " (";
     var value_str = "VALUES (";


### PR DESCRIPTION
When visit_id is null, and the extension attempts to log something, it should send '-1' instead of null to the data aggregator.