### PR TITLE
Change sqlite timeout to 60 seconds to avoid database locking problems.

### DIFF
--- a/automation/DataAggregator/DataAggregator.py
+++ b/automation/DataAggregator/DataAggregator.py
@@ -24,7 +24,7 @@ def DataAggregator(manager_params, status_queue, commit_batch_size=1000):
 
     # sets up DB connection
     db_path = manager_params['database_name']
-    db = sqlite3.connect(db_path, check_same_thread=False)
+    db = sqlite3.connect(db_path, check_same_thread=False, timeout=60)
     curr = db.cursor()
 
     # sets up logging connection


### PR DESCRIPTION
Sometimes a query fails with "database is locked". By changing the timeout from the default value of 5 seconds to 60 seconds, we can maybe avoid that problem. The problem usually looks like this in the logs:

```
DataAggregator       - ERROR    - Unsupported query
<class 'sqlite3.OperationalError'>
database is locked
```