### PR TITLE
Install curl and wget in the installer.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ if [ "$flash" = true ]; then
 fi
 sudo apt-get update
 
-sudo apt-get install -y firefox htop git python-dev libxml2-dev libxslt-dev libffi-dev libssl-dev build-essential xvfb libboost-python-dev libleveldb-dev libjpeg-dev
+sudo apt-get install -y firefox htop git python-dev libxml2-dev libxslt-dev libffi-dev libssl-dev build-essential xvfb libboost-python-dev libleveldb-dev libjpeg-dev curl wget
 
 # For some versions of ubuntu, the package libleveldb1v5 isn't available. Use libleveldb1 instead.
 sudo apt-get install -y libleveldb1v5 || sudo apt-get install -y libleveldb1


### PR DESCRIPTION
Some editions of ubuntu 16.04 such as the default docker images do not come with curl and wget. So just try to install them in install.sh. When they are already installed, they will maybe be updated but it is not supposed to cause any problems.