### PR TITLE
Use IPython < 6.0 for python 2.7.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 beautifulsoup4
 dill
-IPython
+IPython<6.0; python_version < '3.0'
+IPython; python_version >= '3.0'
 mini-amf
 mmh3
 multiprocess

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4
 dill
-IPython<6.0; python_version < '3.0'
-IPython; python_version >= '3.0'
+IPython>=5,0,<6.0; python_version < '3.0'
+IPython>=5.0; python_version >= '3.0'
 mini-amf
 mmh3
 multiprocess

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4
 dill
-IPython>=5,0,<6.0; python_version < '3.0'
+IPython>=5.0,<6.0; python_version < '3.0'
 IPython>=5.0; python_version >= '3.0'
 mini-amf
 mmh3


### PR DESCRIPTION
IPython 6.0 and newer versions do not support python 2.7 anymore. For python 2.7 and older versions, there is still IPython 5.x. When using the default version of pip (8.1.1) in Ubuntu 16.04, the following problem might be encountered when running 'pip install -U -r requirements.txt':

```
    IPython 6.0+ does not support Python 2.6, 2.7, 3.0, 3.1, or 3.2.
    When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
    Beginning with IPython 6.0, Python 3.3 and above is required.

    See IPython `README.rst` file for more information:

        https://github.com/ipython/ipython/blob/master/README.rst

    Python sys.version_info(major=2, minor=7, micro=12, releaselevel='final', serial=0) detected.
```

When using the installer with 'install.sh', then this problem is not encountered since pip is upgraded to a newer version which seems to fix this automatically.