### PR TITLE
Bugfix: display port parsing was incorrect, causing lockfiles to accumulate in /tmp

### DIFF
--- a/automation/BrowserManager.py
+++ b/automation/BrowserManager.py
@@ -246,11 +246,12 @@ class Browser:
                                   "type %s" % (self.crawl_id,
                                                str(self.display_pid)))
         if self.display_port is not None:  # xvfb diplay lock
+            lockfile = "/tmp/.X%s-lock" % self.display_port
             try:
-                os.remove("/tmp/.X"+str(self.display_port)+"-lock")
+                os.remove(lockfile)
             except OSError:
-                self.logger.debug("BROWSER %i: Screen lockfile already "
-                                  "removed" % self.crawl_id)
+                self.logger.debug("BROWSER %i: Screen lockfile (%s) already "
+                                  "removed" % (self.crawl_id, lockfile))
                 pass
         if self.browser_pid is not None:
             """`browser_pid` is the geckodriver process. We first kill

--- a/automation/DeployBrowsers/deploy_firefox.py
+++ b/automation/DeployBrowsers/deploy_firefox.py
@@ -95,7 +95,7 @@ def deploy_firefox(status_queue, browser_params, manager_params,
         display = Display(visible=0, size=profile_settings['screen_res'])
         display.start()
         display_pid = display.pid
-        display_port = display.cmd_param[5][1:]
+        display_port = display.cmd_param[-1][1:]
     status_queue.put(('STATUS', 'Display', (display_pid, display_port)))
 
     # Write extension configuration


### PR DESCRIPTION
The XVFB command format must have changed at some point, causing our
simple index-based parsing of the display port to fail. This bugfix
updates to the new command format by assuming the port is the last item
in the list.