### PR TITLE
Fix crash due to unsuccessful closing of windows

### DIFF
--- a/automation/Commands/browser_commands.py
+++ b/automation/Commands/browser_commands.py
@@ -76,36 +76,20 @@ def close_other_windows(webdriver):
         for window in windows:
             if window != main_handle:
                 webdriver.switch_to_window(window)
+                webdriver.execute_script("window.open = null")
                 webdriver.close()
         webdriver.switch_to_window(main_handle)
 
 
 def tab_restart_browser(webdriver):
     """
-    kills the current tab and creates a new one to stop traffic
+    navigates to about:blank and kills all other windows to stop traffic
     """
-    # note: this technically uses windows, not tabs, due to problems with
-    # chrome-targeted keyboard commands in Selenium 3 (intermittent
-    # nonsense WebDriverExceptions are thrown). windows can be reliably
-    # created, although we do have to detour into JS to do it.
+    webdriver.get("about:blank")
     close_other_windows(webdriver)
 
-    if webdriver.current_url.lower() == 'about:blank':
-        return
-
-    # Create a new window.  Note that it is not practical to use
-    # noopener here, as we would then be forced to specify a bunch of
-    # other "features" that we don't know whether they are on or off.
-    # Closing the old window will kill the opener anyway.
-    webdriver.execute_script("window.open('')")
-
-    # This closes the _old_ window, and does _not_ switch to the new one.
-    webdriver.close()
-
-    # The only remaining window handle will be for the new window;
-    # switch to it.
+    assert webdriver.current_url.lower() == "about:blank"
     assert len(webdriver.window_handles) == 1
-    webdriver.switch_to_window(webdriver.window_handles[0])
 
 
 def get_website(url, sleep, visit_id, webdriver,


### PR DESCRIPTION
Fixes citp/OpenWPM#166

This should fix the referenced issue.
`tab_restart_browser` will now immediately create a new window and change to it (unless the current window is `about:blank`) and let `close_other_windows` close all other windows.
`close_other_windows` will now loop through the list of window handles, as long as there's more than one in it, to kill popups caused by closing windows. This can lead to non-termination, e.g. when a window keeps reopening itself. However, this might be acceptable, as the TaskManager will kill the browser when the timeout period has elapsed.