### PR TITLE
Fix all flake8 issues except for E501

### DIFF
--- a/test/expected.py
+++ b/test/expected.py
@@ -1,6 +1,6 @@
 """ Contains lists of expected data and or rows for tests """
 from __future__ import absolute_import
-from .utilities import BASE_TEST_URL, BASE_TEST_URL_DOMAIN, BASE_TEST_URL_NOPATH
+from .utilities import BASE_TEST_URL, BASE_TEST_URL_DOMAIN
 
 # XXX DO NOT PLACE NEW PROPERTIES HERE. Move anything you need to edit out
 # XXX of this file and into the respective test file. See Issue #73.

--- a/test/manual_test.py
+++ b/test/manual_test.py
@@ -158,7 +158,7 @@ def main():
         logger = Logger()  # noqa
         IPython.embed()
     else:
-        print ("Unrecognized arguments. Usage:\n"
+        print("Unrecognized arguments. Usage:\n"
                "python manual_test.py ('--selenium')? ('--no-extension')?")
 
 

--- a/test/test_crawl.py
+++ b/test/test_crawl.py
@@ -87,7 +87,7 @@ class TestCrawl(OpenWPMTest):
         hist_ps = set()  # visited domains from CrawlHistory Table
         successes = dict()
         rows = db_utils.query_db(crawl_db, "SELECT arguments, bool_success "
-                                  "FROM CrawlHistory WHERE command='GET'")
+                                 "FROM CrawlHistory WHERE command='GET'")
         for url, success in rows:
             ps = psl.get_public_suffix(urlparse(url).hostname)
             hist_ps.add(ps)
@@ -115,22 +115,22 @@ class TestCrawl(OpenWPMTest):
 
             # Get the visit id for the url
             rows = db_utils.query_db(crawl_db,
-                                      "SELECT visit_id FROM site_visits "
-                                      "WHERE site_url = ?",
-                                      ('http://' + url,))
+                                     "SELECT visit_id FROM site_visits "
+                                     "WHERE site_url = ?",
+                                     ('http://' + url,))
             visit_id = rows[0]
 
             rows = db_utils.query_db(crawl_db,
-                                      "SELECT COUNT(*) FROM http_responses "
-                                      "WHERE visit_id = ?",
-                                      (visit_id,))
+                                     "SELECT COUNT(*) FROM http_responses "
+                                     "WHERE visit_id = ?",
+                                     (visit_id,))
             if rows[0] > 1:
                 continue
 
             rows = db_utils.query_db(crawl_db,
-                                      "SELECT response_status, location FROM "
-                                      "http_responses WHERE visit_id = ?",
-                                      (visit_id,))
+                                     "SELECT response_status, location FROM "
+                                     "http_responses WHERE visit_id = ?",
+                                     (visit_id,))
             response_status, location = rows[0]
             if response_status == 204:
                 continue

--- a/test/test_custom_function_command.py
+++ b/test/test_custom_function_command.py
@@ -37,7 +37,7 @@ class TestCustomFunctionCommand(OpenWPMTest):
                     element.get_attribute("href")
                     for element in driver.find_elements_by_tag_name('a')
                 )
-                if x.startswith(scheme+'://')
+                if x.startswith(scheme + '://')
             ]
             current_url = driver.current_url
 

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -252,8 +252,8 @@ class TestExtension(OpenWPMTest):
         assert WEBRTC_CALLS == observed_rows
 
     @pytest.mark.skipif(
-       "TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
-       reason='Flaky on Travis CI')
+        "TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
+        reason='Flaky on Travis CI')
     def test_audio_fingerprinting(self):
         db = self.visit('/audio_fingerprinting.html')
         # Check that all calls and methods are recorded

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -20,30 +20,30 @@ class TestProfile(OpenWPMTest):
         manager = TaskManager.TaskManager(manager_params, browser_params)
         manager.get('http://example.com')
         manager.close()
-        assert isfile(join(browser_params[0]['profile_archive_dir'],'profile.tar.gz'))
+        assert isfile(join(browser_params[0]['profile_archive_dir'], 'profile.tar.gz'))
 
     def test_crash(self):
         manager_params, browser_params = self.get_config()
         manager_params['failure_limit'] = 0
         manager = TaskManager.TaskManager(manager_params, browser_params)
         with pytest.raises(CommandExecutionError):
-            manager.get('http://example.com') # So we have a profile
-            manager.get('example.com') # Selenium requires scheme prefix
-            manager.get('example.com') # Requires two commands to shut down
+            manager.get('http://example.com')  # So we have a profile
+            manager.get('example.com')  # Selenium requires scheme prefix
+            manager.get('example.com')  # Requires two commands to shut down
 
     def test_crash_profile(self):
         manager_params, browser_params = self.get_config()
         manager_params['failure_limit'] = 2
         manager = TaskManager.TaskManager(manager_params, browser_params)
         try:
-            manager.get('http://example.com') # So we have a profile
-            manager.get('example.com') # Selenium requires scheme prefix
-            manager.get('example.com') # Selenium requires scheme prefix
-            manager.get('example.com') # Selenium requires scheme prefix
-            manager.get('example.com') # Requires two commands to shut down
+            manager.get('http://example.com')  # So we have a profile
+            manager.get('example.com')  # Selenium requires scheme prefix
+            manager.get('example.com')  # Selenium requires scheme prefix
+            manager.get('example.com')  # Selenium requires scheme prefix
+            manager.get('example.com')  # Requires two commands to shut down
         except CommandExecutionError:
             pass
-        assert isfile(join(browser_params[0]['profile_archive_dir'],'profile.tar.gz'))
+        assert isfile(join(browser_params[0]['profile_archive_dir'], 'profile.tar.gz'))
 
     def test_profile_error(self):
         manager_params, browser_params = self.get_config()
@@ -62,9 +62,9 @@ class TestProfile(OpenWPMTest):
         # Kill the LevelDBAggregator
         # This will cause the proxy launch to crash
         manager.ldb_status_queue.put("DIE")
-        manager.browsers[0]._SPAWN_TIMEOUT = 2 # Have timeout occur quickly
-        manager.browsers[0]._UNSUCCESSFUL_SPAWN_LIMIT = 2 # Have timeout occur quickly
-        manager.get('example.com') # Cause a selenium crash to force browser to restart
+        manager.browsers[0]._SPAWN_TIMEOUT = 2  # Have timeout occur quickly
+        manager.browsers[0]._UNSUCCESSFUL_SPAWN_LIMIT = 2  # Have timeout occur quickly
+        manager.get('example.com')  # Cause a selenium crash to force browser to restart
 
         # The browser will fail to launch due to the proxy crashes
         try:
@@ -72,7 +72,8 @@ class TestProfile(OpenWPMTest):
         except CommandExecutionError:
             pass
         manager.close()
-        assert isfile(join(browser_params[0]['profile_archive_dir'],'profile.tar.gz'))
+        assert isfile(join(browser_params[0]['profile_archive_dir'], 'profile.tar.gz'))
 
-    #TODO Check for Flash
-    #TODO Check contents of profile (tests should fail anyway if profile doesn't contain everything)
+    """ TODO Check for Flash
+    TODO Check contents of profile (tests should fail anyway if profile doesn't contain everything)
+    """

--- a/test/test_simple_commands.py
+++ b/test/test_simple_commands.py
@@ -389,7 +389,7 @@ class TestSimpleCommands(OpenWPMTest):
             # Verify source
             path = urlparse(frame['doc_url']).path
             expected_source = ''
-            with open('.'+path, 'r') as f:
+            with open('.' + path, 'r') as f:
                 expected_source = re.sub('\s', '', f.read().lower())
                 if expected_source.startswith('<!doctypehtml>'):
                     expected_source = expected_source[14:]

--- a/test/test_storage_vectors.py
+++ b/test/test_storage_vectors.py
@@ -6,28 +6,28 @@ from ..automation.utilities import db_utils
 from .openwpmtest import OpenWPMTest
 
 expected_lso_content_a = [
-               1,  # visit id
-               u'localtest.me',
-               u'FlashCookie.sol',
-               u'localtest.me/FlashCookie.sol',
-               u'test_key',
-               u'REPLACEME']
+    1,  # visit id
+    u'localtest.me',
+    u'FlashCookie.sol',
+    u'localtest.me/FlashCookie.sol',
+    u'test_key',
+    u'REPLACEME']
 
 expected_lso_content_b = [
-               2,  # visit id
-               u'localtest.me',
-               u'FlashCookie.sol',
-               u'localtest.me/FlashCookie.sol',
-               u'test_key',
-               u'REPLACEME']
+    2,  # visit id
+    u'localtest.me',
+    u'FlashCookie.sol',
+    u'localtest.me/FlashCookie.sol',
+    u'test_key',
+    u'REPLACEME']
 
 expected_js_cookie = (
-             1,  # visit id
-             u'%s' % utilities.BASE_TEST_URL_DOMAIN,
-             u'test_cookie',
-             u'Test-0123456789',
-             u'%s' % utilities.BASE_TEST_URL_DOMAIN,
-             u'/')
+    1,  # visit id
+    u'%s' % utilities.BASE_TEST_URL_DOMAIN,
+    u'test_cookie',
+    u'Test-0123456789',
+    u'%s' % utilities.BASE_TEST_URL_DOMAIN,
+    u'/')
 
 
 class TestStorageVectors(OpenWPMTest):


### PR DESCRIPTION
This patch addresses all ```flake8``` issues (in the test/ dir) except for E501, so helps with https://github.com/citp/OpenWPM/issues/116 (but doesn't obviate further fixes).  And, if accepted, we'll need it *before* we merge in https://github.com/citp/OpenWPM/pull/199.

```
./test_profile.py:23:68: E231 missing whitespace after ','
./test_profile.py:23:80: E501 line too long (86 > 79 characters)
./test_profile.py:30:46: E261 at least two spaces before inline comment
./test_profile.py:31:39: E261 at least two spaces before inline comment
./test_profile.py:32:39: E261 at least two spaces before inline comment
./test_profile.py:39:46: E261 at least two spaces before inline comment
./test_profile.py:40:39: E261 at least two spaces before inline comment
./test_profile.py:41:39: E261 at least two spaces before inline comment
./test_profile.py:42:39: E261 at least two spaces before inline comment
./test_profile.py:43:39: E261 at least two spaces before inline comment
./test_profile.py:46:68: E231 missing whitespace after ','
./test_profile.py:46:80: E501 line too long (86 > 79 characters)
./test_profile.py:65:47: E261 at least two spaces before inline comment
./test_profile.py:66:58: E261 at least two spaces before inline comment
./test_profile.py:66:80: E501 line too long (86 > 79 characters)
./test_profile.py:67:35: E261 at least two spaces before inline comment
./test_profile.py:67:80: E501 line too long (87 > 79 characters)
./test_profile.py:75:68: E231 missing whitespace after ','
./test_profile.py:75:80: E501 line too long (86 > 79 characters)
./test_profile.py:77:5: E265 block comment should start with '# '
./test_profile.py:78:5: E265 block comment should start with '# '
./test_profile.py:78:80: E501 line too long (100 > 79 characters)
./test_crawl.py:90:35: E127 continuation line over-indented for visual indent
./test_crawl.py:109:80: E501 line too long (94 > 79 characters)
./test_crawl.py:118:39: E127 continuation line over-indented for visual indent
./test_crawl.py:124:39: E127 continuation line over-indented for visual indent
./test_crawl.py:131:39: E127 continuation line over-indented for visual indent
./expected.py:3:1: F401 '.utilities.BASE_TEST_URL_NOPATH' imported but unused
./expected.py:3:80: E501 line too long (80 > 79 characters)
```

Also note: we've been running with ```flake8-isort==2.5``` - not sure if you're interested in adding that, but I'd be happy to help, if so!