### PR TITLE
Give the thread for socketserver a name.

### DIFF
--- a/automation/DataAggregator/DataAggregator.py
+++ b/automation/DataAggregator/DataAggregator.py
@@ -31,7 +31,7 @@ def DataAggregator(manager_params, status_queue, commit_batch_size=1000):
     logger = loggingclient(*manager_params['logger_address'])
 
     # sets up the serversocket to start accepting connections
-    sock = serversocket()
+    sock = serversocket(name="DataAggregator")
     status_queue.put(sock.sock.getsockname())  # let TM know location
     sock.start_accepting()
 

--- a/automation/DataAggregator/LevelDBAggregator.py
+++ b/automation/DataAggregator/LevelDBAggregator.py
@@ -24,7 +24,7 @@ def LevelDBAggregator(manager_params, status_queue, batch_size=100):
     logger = loggingclient(*manager_params['logger_address'])
 
     # sets up the serversocket to start accepting connections
-    sock = serversocket()
+    sock = serversocket(name="LevelDBAggregator")
     status_queue.put(sock.sock.getsockname())  # let TM know location
     sock.start_accepting()
 

--- a/automation/MPLogger.py
+++ b/automation/MPLogger.py
@@ -71,7 +71,7 @@ def loggingserver(log_file, status_queue):
             level=logging.INFO)
 
     # Sets up the serversocket to start accepting connections
-    sock = serversocket()
+    sock = serversocket(name="loggingserver")
     status_queue.put(sock.sock.getsockname())  # let TM know location
     sock.start_accepting()
 

--- a/automation/SocketInterface.py
+++ b/automation/SocketInterface.py
@@ -19,11 +19,12 @@ class serversocket:
     A server socket to recieve and process string messages
     from client sockets to a central queue
     """
-    def __init__(self, verbose=False):
+    def __init__(self, name=None, verbose=False):
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.bind(('localhost', 0))
         self.sock.listen(10)  # queue a max of n connect requests
         self.verbose = verbose
+        self.name = name
         self.queue = Queue()
         if self.verbose:
             print("Server bound to: " + str(self.sock.getsockname()))
@@ -32,6 +33,8 @@ class serversocket:
         """ Start the listener thread """
         thread = threading.Thread(target=self._accept, args=())
         thread.daemon = True  # stops from blocking shutdown
+        if self.name is not None:
+            thread.name = thread.name + "-" + self.name
         thread.start()
 
     def _accept(self):


### PR DESCRIPTION
By giving the thread that accepts the socket connections in socketserver a name, the code should be easier to debug so that in case an exception happens, it is clear in which thread it happened.

This will not fix issue #145 but it will help at least to debug it.