### PR TITLE
[WIP] Run Travis tests using pytest-xdist for concurrency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,7 @@ python:
  - "3.5"
  - "3.6"
 env:
-# See, https://docs.travis-ci.com/user/speeding-up-the-build/
-# We need a balanced distribution of the tests
-# Once we add and remove tests, this distribution may become unbalanced.
-# Feel free to move tests around to make the running time of the jobs
-# as close as possible.
-  - TESTS=test_[a-b,d-e]*
-# test_crawl.py is the longest running test.
-  - TESTS=test_c*
-  - TESTS=test_[f-h]*
-  - TESTS=test_[i-z]*
+  - TESTS=test_*
 git:
   depth: 3
 before_install:
@@ -30,4 +21,4 @@ before_script:
   - cd test
 script:
   - flake8
-  - py.test -s -v --durations=10 $TESTS
+  - py.test -n=auto -s -v --durations=10 $TESTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ before_script:
   - cd test
 script:
   - flake8
-  - py.test -n=auto -s -v --durations=10 $TESTS
+  - py.test -n=1 -s -v --durations=10 $TESTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,16 @@ python:
  - "3.5"
  - "3.6"
 env:
-  - TESTS=test_*
+# See, https://docs.travis-ci.com/user/speeding-up-the-build/
+# We need a balanced distribution of the tests
+# Once we add and remove tests, this distribution may become unbalanced.
+# Feel free to move tests around to make the running time of the jobs
+# as close as possible.
+  - TESTS=test_[a-b,d-e]*
+# test_crawl.py is the longest running test.
+  - TESTS=test_c*
+  - TESTS=test_[f-h]*
+  - TESTS=test_[i-z]*
 git:
   depth: 3
 before_install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ publicsuffix
 pyasn1
 PyOPenSSL
 pytest
+pytest-xdist
 python-dateutil
 pyvirtualdisplay
 setuptools

--- a/test/openwpmtest.py
+++ b/test/openwpmtest.py
@@ -63,7 +63,8 @@ class OpenWPMTest(object):
                             "beautifulsoup4": "bs4",
                             "python-dateutil": "dateutil",
                             "mini-amf": "miniamf",
-                            "pillow": "PIL"
+                            "pillow": "PIL",
+                            "pytest-xdist": "pytest"
                             }
         # get the mapped name if it exists.
         pkg_importable = pkg_name_mapping.get(pkg.lower(), pkg)


### PR DESCRIPTION
Got a ways to go, here; we'll have to smartly deal with having enough unique webserver ports, dynamically, if we're going to go the pytest-xdist route, due to the current hardcode in https://github.com/citp/OpenWPM/blob/7be2dec15807a46f86876eea480696b1584ab9ec/test/utilities.py#L13