### PR TITLE
Fix Dockerfile-dev build, by ADDing requirements-dev.txt to /opt/Open…

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -11,6 +11,7 @@ FROM openwpm
 
 ADD test /opt/OpenWPM/test/
 ADD install-dev.sh /opt/OpenWPM/
+ADD requirements-dev.txt /opt/OpenWPM/
 
 #=============================================================
 # Install requirements for OpenWPM development


### PR DESCRIPTION
…WPM/

@englehardt r?

```Dockerfile-dev``` build output on master:

```
Could not open requirements file: [Errno 2] No such file or directory: 'requirements-dev.txt'
The command '/bin/sh -c cd /opt/OpenWPM/ && ./install-dev.sh' returned a non-zero code: 1
```

See https://gist.github.com/stephendonner/de8d4b623b3c89cdafaa667466cd9965 for moar output.