### PR TITLE
Align SQL and parquet schemas

### DIFF
--- a/automation/DataAggregator/parquet_schema.py
+++ b/automation/DataAggregator/parquet_schema.py
@@ -12,21 +12,20 @@ PQ_SCHEMAS['site_visits'] = pa.schema(fields)
 
 # flash_cookies
 fields = [
-    pa.field('visit_id', pa.uint32(), nullable=False),
     pa.field('crawl_id', pa.uint32(), nullable=False),
+    pa.field('visit_id', pa.uint32(), nullable=False),
     pa.field('domain', pa.string()),
     pa.field('filename', pa.string()),
     pa.field('local_path', pa.string()),
     pa.field('key', pa.string()),
-    pa.field('content', pa.string()),
     pa.field('content', pa.string())
 ]
 PQ_SCHEMAS['flash_cookies'] = pa.schema(fields)
 
 # profile_cookies
 fields = [
-    pa.field('visit_id', pa.uint32(), nullable=False),
     pa.field('crawl_id', pa.uint32(), nullable=False),
+    pa.field('visit_id', pa.uint32(), nullable=False),
     pa.field('baseDomain', pa.string()),
     pa.field('name', pa.string()),
     pa.field('value', pa.string()),
@@ -42,8 +41,8 @@ PQ_SCHEMAS['profile_cookies'] = pa.schema(fields)
 
 # crawl_history
 fields = [
-    pa.field('visit_id', pa.uint32(), nullable=False),
     pa.field('crawl_id', pa.uint32(), nullable=False),
+    pa.field('visit_id', pa.uint32(), nullable=False),
     pa.field('command', pa.string()),
     pa.field('arguments', pa.string()),
     pa.field('bool_success', pa.int8()),
@@ -52,8 +51,8 @@ PQ_SCHEMAS['crawl_history'] = pa.schema(fields)
 
 # http_requests
 fields = [
-    pa.field('visit_id', pa.uint32(), nullable=False),
     pa.field('crawl_id', pa.uint32(), nullable=False),
+    pa.field('visit_id', pa.uint32(), nullable=False),
     pa.field('url', pa.string(), nullable=False),
     pa.field('top_level_url', pa.string()),
     pa.field('method', pa.string(), nullable=False),
@@ -71,13 +70,14 @@ fields = [
     pa.field('req_call_stack', pa.string()),
     pa.field('content_policy_type', pa.uint8(), nullable=False),
     pa.field('post_body', pa.string())
+    // missing: time_stamp
 ]
 PQ_SCHEMAS['http_requests'] = pa.schema(fields)
 
 # http_responses
 fields = [
-    pa.field('visit_id', pa.uint32(), nullable=False),
     pa.field('crawl_id', pa.uint32(), nullable=False),
+    pa.field('visit_id', pa.uint32(), nullable=False),
     pa.field('url', pa.string(), nullable=False),
     pa.field('method', pa.string(), nullable=False),
     pa.field('referrer', pa.string(), nullable=False),
@@ -94,8 +94,8 @@ PQ_SCHEMAS['http_responses'] = pa.schema(fields)
 
 # http_redirects
 fields = [
-    pa.field('visit_id', pa.uint32(), nullable=False),
     pa.field('crawl_id', pa.uint32(), nullable=False),
+    pa.field('visit_id', pa.uint32(), nullable=False),
     pa.field('old_channel_id', pa.string()),
     pa.field('new_channel_id', pa.string()),
     pa.field('is_temporary', pa.bool_(), nullable=False),
@@ -108,8 +108,8 @@ PQ_SCHEMAS['http_redirects'] = pa.schema(fields)
 
 # javascript
 fields = [
-    pa.field('visit_id', pa.uint32(), nullable=False),
     pa.field('crawl_id', pa.uint32(), nullable=False),
+    pa.field('visit_id', pa.uint32(), nullable=False),
     pa.field('script_url', pa.string()),
     pa.field('script_line', pa.string()),
     pa.field('script_col', pa.string()),
@@ -128,8 +128,8 @@ PQ_SCHEMAS['javascript'] = pa.schema(fields)
 
 # javascript_cookies
 fields = [
-    pa.field('visit_id', pa.uint32(), nullable=False),
     pa.field('crawl_id', pa.uint32(), nullable=False),
+    pa.field('visit_id', pa.uint32(), nullable=False),
     pa.field('change', pa.string()),
     pa.field('creationTime', pa.string()),
     pa.field('expiry', pa.string()),

--- a/automation/schema.sql
+++ b/automation/schema.sql
@@ -17,12 +17,14 @@ CREATE TABLE IF NOT EXISTS crawl (
     start_time DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY(task_id) REFERENCES task(task_id));
 
+# site_visits
 CREATE TABLE IF NOT EXISTS site_visits (
     visit_id INTEGER PRIMARY KEY,
     crawl_id INTEGER NOT NULL,
     site_url VARCHAR(500) NOT NULL,
     FOREIGN KEY(crawl_id) REFERENCES crawl(id));
 
+# flash_cookies
 CREATE TABLE IF NOT EXISTS flash_cookies (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     crawl_id INTEGER NOT NULL,
@@ -35,6 +37,7 @@ CREATE TABLE IF NOT EXISTS flash_cookies (
     FOREIGN KEY(crawl_id) REFERENCES crawl(id),
     FOREIGN KEY(visit_id) REFERENCES site_visits(id));
 
+# profile_cookies
 CREATE TABLE IF NOT EXISTS profile_cookies (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     crawl_id INTEGER NOT NULL,
@@ -52,6 +55,7 @@ CREATE TABLE IF NOT EXISTS profile_cookies (
     FOREIGN KEY(crawl_id) REFERENCES crawl(id),
     FOREIGN KEY(visit_id) REFERENCES site_visits(id));
 
+# crawl_history
 CREATE TABLE IF NOT EXISTS crawl_history (
     crawl_id INTEGER,
     visit_id INTEGER,
@@ -61,6 +65,7 @@ CREATE TABLE IF NOT EXISTS crawl_history (
     dtg DATETIME DEFAULT (CURRENT_TIMESTAMP),
     FOREIGN KEY(crawl_id) REFERENCES crawl(id));
 
+# http_requests
 CREATE TABLE IF NOT EXISTS http_requests(
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     crawl_id INTEGER NOT NULL,
@@ -85,6 +90,7 @@ CREATE TABLE IF NOT EXISTS http_requests(
     time_stamp TEXT NOT NULL
 );
 
+# http_responses
 CREATE TABLE IF NOT EXISTS http_responses(
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     crawl_id INTEGER NOT NULL,
@@ -102,6 +108,7 @@ CREATE TABLE IF NOT EXISTS http_responses(
     content_hash TEXT
 );
 
+# http_redirects
 CREATE TABLE IF NOT EXISTS http_redirects(
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     crawl_id INTEGER NOT NULL,
@@ -115,6 +122,7 @@ CREATE TABLE IF NOT EXISTS http_redirects(
     time_stamp TEXT NOT NULL
 );
 
+# javascript
 CREATE TABLE IF NOT EXISTS javascript(
     id INTEGER PRIMARY KEY,
     crawl_id INTEGER,
@@ -134,6 +142,7 @@ CREATE TABLE IF NOT EXISTS javascript(
     time_stamp TEXT NOT NULL
 );
 
+# javascript_cookies
 CREATE TABLE IF NOT EXISTS javascript_cookies(
     id INTEGER PRIMARY KEY ASC,
     crawl_id INTEGER,


### PR DESCRIPTION
I noticed these inconsistencies when creating [the client side typescript interfaces corresponding to the OpenWPM schemata](https://github.com/mozilla/openwpm-webext-instrumentation/blob/master/src/types/schema.d.ts).

Note: Adding table-name comments to the SQL schema allows for `diff -y automation/schema.sql automation/DataAggregator/parquet_schema.py` to present a side-by-side comparison of the schemas.